### PR TITLE
Update incremental search to start at page 1 instead of 0

### DIFF
--- a/src/test/kotlin/app/shosetsu/lib/Test.kt
+++ b/src/test/kotlin/app/shosetsu/lib/Test.kt
@@ -352,7 +352,7 @@ object Test {
 									extension.search(
 										HashMap(searchFiltersModel).apply {
 											set(QUERY_INDEX, SEARCH_VALUE)
-											set(PAGE_INDEX, 0)
+											set(PAGE_INDEX, 1)
 										}
 									)
 								}


### PR DESCRIPTION
Seems to me like a mistake that the incremental search starts with page 0 instead of 1 and then goes to page 2 afterwards. 