### PR TITLE
Remove KTS support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,14 +42,14 @@ dependencies {
 	testImplementation(kotlin("stdlib"))
 	testImplementation(kotlin("stdlib-jdk8"))
 
-	testImplementation("net.java.dev.jna:jna:5.8.0") // for KTS
+	//testImplementation("net.java.dev.jna:jna:5.8.0") // for KTS
 
 	testImplementation(kotlin("reflect"))
-	testImplementation(kotlin("script-runtime"))
-	testImplementation(kotlin("script-util"))
-	testImplementation(kotlin("compiler-embeddable"))
-	testImplementation(kotlin("scripting-compiler-embeddable"))
-	testImplementation(kotlin("script-util"))
+	//testImplementation(kotlin("script-runtime"))
+	//testImplementation(kotlin("script-util"))
+	//testImplementation(kotlin("compiler-embeddable"))
+	//testImplementation(kotlin("scripting-compiler-embeddable"))
+	//testImplementation(kotlin("script-util"))
 
 	testImplementation(kotlin("test"))
 }

--- a/src/main/kotlin/app/shosetsu/lib/ExtensionType.kt
+++ b/src/main/kotlin/app/shosetsu/lib/ExtensionType.kt
@@ -8,5 +8,6 @@ enum class ExtensionType {
 	LuaScript,
 
 	/** .kts */
+	@Deprecated("Does not work on android")
 	KotlinScript
 }

--- a/src/main/kotlin/app/shosetsu/lib/kts/KtsExtension.kt
+++ b/src/main/kotlin/app/shosetsu/lib/kts/KtsExtension.kt
@@ -1,8 +1,7 @@
 package app.shosetsu.lib.kts
-
+/*
 import app.shosetsu.lib.IExtension
 import java.io.File
-import kotlin.time.ExperimentalTime
 
 /**
  * shosetsu-services
@@ -14,3 +13,4 @@ class KtsExtension(
 ) : IExtension by _kts {
 	constructor(file: File) : this(file.readText())
 }
+*/

--- a/src/main/kotlin/app/shosetsu/lib/kts/KtsObjectLoader.kt
+++ b/src/main/kotlin/app/shosetsu/lib/kts/KtsObjectLoader.kt
@@ -1,5 +1,5 @@
 package app.shosetsu.lib.kts
-
+/*
 import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
 
@@ -20,3 +20,4 @@ class KtsObjectLoader(classLoader: ClassLoader? = Thread.currentThread().context
 			.getOrElse @Throws(RuntimeException::class) { throw RuntimeException("Cannot load script", it) }
 			.castOrError()
 }
+ */

--- a/src/main/kotlin/app/shosetsu/lib/kts/ShosetsuKtsLib.kt
+++ b/src/main/kotlin/app/shosetsu/lib/kts/ShosetsuKtsLib.kt
@@ -1,5 +1,5 @@
 package app.shosetsu.lib.kts
-
+/*
 import app.shosetsu.lib.ShosetsuSharedLib.httpClient
 import app.shosetsu.lib.exceptions.HTTPException
 import app.shosetsu.lib.lua.ShosetsuLuaLib.LibFunctions.RequestDocument
@@ -47,3 +47,5 @@ object ShosetsuKtsLib {
 
 	fun getDocument(url: String): Document = RequestDocument(get(url, defaultHeaders, defaultCacheControl))
 }
+
+ */

--- a/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/src/main/resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,1 +1,0 @@
-org.jetbrains.kotlin.script.jsr223.KotlinJsr223JvmLocalScriptEngineFactory

--- a/src/test/kotlin/app/shosetsu/lib/Test.kt
+++ b/src/test/kotlin/app/shosetsu/lib/Test.kt
@@ -4,7 +4,6 @@ import app.shosetsu.lib.ExtensionType.KotlinScript
 import app.shosetsu.lib.ExtensionType.LuaScript
 import app.shosetsu.lib.ShosetsuSharedLib.httpClient
 import app.shosetsu.lib.json.RepoIndex
-import app.shosetsu.lib.kts.KtsExtension
 import app.shosetsu.lib.lua.LuaExtension
 import app.shosetsu.lib.lua.ShosetsuLuaLib
 import app.shosetsu.lib.lua.shosetsuGlobals
@@ -268,7 +267,7 @@ object Test {
 							val file = File(extensionPath.first)
 							when (extensionPath.second) {
 								LuaScript -> LuaExtension(file)
-								KotlinScript -> KtsExtension(file)
+								KotlinScript -> throw Exception("Stub")
 							}
 						}
 


### PR DESCRIPTION
KTS cannot be run on android, making it quite useless. Removal shall lower the size of Shosetsu.

If KTS is ever expanded or fleshed out to be properly multiplatform, it can be restored.