### PR TITLE
Add delay function for Lua scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
 	// ### Core Libraries
 	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
+	implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.1") // For MPP time control
 
 	// java only
 	implementation("org.jsoup:jsoup:1.13.1")

--- a/src/main/kotlin/app/shosetsu/lib/lua/ShosetsuLuaLib.kt
+++ b/src/main/kotlin/app/shosetsu/lib/lua/ShosetsuLuaLib.kt
@@ -3,6 +3,7 @@ package app.shosetsu.lib.lua
 import app.shosetsu.lib.*
 import app.shosetsu.lib.exceptions.HTTPException
 import app.shosetsu.lib.exceptions.MissingExtensionLibrary
+import kotlinx.datetime.Clock
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -241,6 +242,17 @@ class ShosetsuLuaLib : TwoArgFunction() {
 
 		fun Log(name: String, arguments: String) {
 			ShosetsuSharedLib.logger(name, arguments)
+		}
+
+		/**
+		 * Delay by [milliseconds]
+		 */
+		fun delay(milliseconds: Long) {
+			val startTime = Clock.System.now().toEpochMilliseconds()
+			var currentTime: Long
+			do {
+				currentTime = Clock.System.now().toEpochMilliseconds()
+			} while (startTime + milliseconds > currentTime)
 		}
 	}
 

--- a/src/test/kotlin/app/shosetsu/lib/LuaLibTest.kt
+++ b/src/test/kotlin/app/shosetsu/lib/LuaLibTest.kt
@@ -1,0 +1,21 @@
+package app.shosetsu.lib
+
+import app.shosetsu.lib.lua.shosetsuGlobals
+import org.junit.Test
+import kotlin.system.measureTimeMillis
+
+/*
+ * shosetsu-kotlin-lib
+ * 02 / 11 / 2021
+ */
+class LuaLibTest {
+	@Test
+	fun delayTest() {
+		val time = 500L
+		val script = shosetsuGlobals().load("delay($time)", "delayTest")!!
+
+		val resultTime = measureTimeMillis { script.call() }
+
+		assert(resultTime > time) { "func 'delay' time < ${time}ms" }
+	}
+}


### PR DESCRIPTION
Utilizing the kotlin time library, establish method to delay a scripts
 process for a certain amount of milliseconds.


@TechnoJo4 Can you check how long it takes you to run a delay, for me there was an overhead of 23~ ms when using `delay`