### PR TITLE
Mark required libraries as API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,12 +30,12 @@ dependencies {
 	dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.6.20")
 
 	// ### Core Libraries
-	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
+	api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
 
 	// java only
-	implementation("org.jsoup:jsoup:1.15.1")
-	implementation("org.luaj:luaj-jse:3.0.1")
-	implementation("com.squareup.okhttp3:okhttp:4.9.3")
+	api("org.jsoup:jsoup:1.15.1")
+	api("org.luaj:luaj-jse:3.0.1")
+	api("com.squareup.okhttp3:okhttp:4.9.3")
 	implementation("com.google.guava:guava:31.1-jre")
 
 


### PR DESCRIPTION
This will lower the declaration redundancy in Shosetsu projects